### PR TITLE
fix: copilot proxy latest docker hub was broken

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,9 @@ services:
               count: all
               capabilities: [gpu]
   copilot_proxy:
-    image: moyix/copilot_proxy:latest
+    build:
+      context: ./copilot_proxy/
+      dockerfile: Dockerfile
     command: python3 -m flask run --host=0.0.0.0 --port=5000
     ports:
       - "5000:5000"


### PR DESCRIPTION
`moyix/copilot_proxy:latest` is broken as of now

simple fix to build docker image locally instead of pulling it

appreciate what yall are doing with faux pilot :)